### PR TITLE
Add CI job for auto-bumping Dask version

### DIFF
--- a/.github/workflows/ci-bump-dask.yml
+++ b/.github/workflows/ci-bump-dask.yml
@@ -18,7 +18,7 @@ jobs:
           org: "conda-forge"
           package: "dask"
 
-      - name: Find and replace coiled version
+      - name: Find and replace Dask version
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
           find: "dask=.* "

--- a/.github/workflows/ci-bump-dask.yml
+++ b/.github/workflows/ci-bump-dask.yml
@@ -1,0 +1,38 @@
+name: Check for new Dask version on conda-forge
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    if: github.repository == 'coiled/software-environments'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get latest Dask version
+        id: latest_version
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
+        with:
+          org: "conda-forge"
+          package: "dask"
+
+      - name: Find and replace coiled version
+        uses: jacobtomlinson/gha-find-replace@0.1.1
+        with:
+          find: "dask=.* "
+          replace: "dask=${{ steps.latest_version.outputs.version }} "
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
+          title: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
+          reviewers: "jrbourbeau"
+          branch: "upgrade-package-versions"
+          body: |
+            A new Dask version has been detected.
+
+            Updated Dask to `${{ steps.latest_version.outputs.version }}`.


### PR DESCRIPTION
This PR adds a GitHub actions workflow which will check conda-forge every hour for a new release and then open a PR to this repository which updates the Dask version in the conda environment files here 