### PR TITLE
Don't upgrade pandas (yet)

### DIFF
--- a/default/environment-py37.yml
+++ b/default/environment-py37.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask=2021.6.2 
   - lz4
   - numpy>=1.19.0
-  - pandas>=1.1.0
+  - pandas>=1.1.0,<1.3.0  # TODO: switch to >= 1.3.0
   - bokeh>=2.1.1
   - dask-image>=0.3.0
   - dask-ml>=1.5.0

--- a/default/environment-py38.yml
+++ b/default/environment-py38.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask=2021.6.2 
   - lz4
   - numpy>=1.19.0
-  - pandas>=1.1.0
+  - pandas>=1.1.0,<1.3.0  # TODO: switch to >= 1.3.0
   - bokeh>=2.1.1
   - dask-image>=0.3.0
   - dask-ml>=1.5.0

--- a/default/environment-py39.yml
+++ b/default/environment-py39.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask=2021.6.2 
   - lz4
   - numpy>=1.19.0
-  - pandas>=1.1.0
+  - pandas>=1.1.0,<1.3.0  # TODO: switch to >= 1.3.0
   - bokeh>=2.1.1
   - dask-image>=0.3.0
   - dask-ml>=1.5.0


### PR DESCRIPTION
Avoids most recent version of pandas as it has changed the pickling
protocol. This isn't wrong, but it means that different versions of
pandas on the client and workers can run into troubles. So for now,
prevent an upgrade in the default environments until more people have
had a chance to upgrade themselves.