### PR TITLE
Pandas>=1.3.0

### DIFF
--- a/default/environment-py37.yml
+++ b/default/environment-py37.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask=2021.7.0 
   - lz4
   - numpy>=1.19.0
-  - pandas>=1.1.0,<1.3.0  # TODO: switch to >= 1.3.0
+  - pandas>=1.3.0
   - bokeh>=2.1.1
   - dask-image>=0.3.0
   - dask-ml>=1.5.0

--- a/default/environment-py38.yml
+++ b/default/environment-py38.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask=2021.7.0 
   - lz4
   - numpy>=1.19.0
-  - pandas>=1.1.0,<1.3.0  # TODO: switch to >= 1.3.0
+  - pandas>=1.3.0
   - bokeh>=2.1.1
   - dask-image>=0.3.0
   - dask-ml>=1.5.0

--- a/default/environment-py39.yml
+++ b/default/environment-py39.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask=2021.7.0 
   - lz4
   - numpy>=1.19.0
-  - pandas>=1.1.0,<1.3.0  # TODO: switch to >= 1.3.0
+  - pandas>=1.3.0
   - bokeh>=2.1.1
   - dask-image>=0.3.0
   - dask-ml>=1.5.0


### PR DESCRIPTION
Now that pandas 1.3.0 has been released for a few days, and people are starting to run into incompatibilities with our default software environments, bump the version.