### PR TITLE
Set dask to 2022.1.1 due to stability problems

### DIFF
--- a/default/environment-py37.yml
+++ b/default/environment-py37.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - python-blosc
   - cytoolz
-  - dask=2022.4.0
+  - dask=2022.1.1  # Versions after this are known to be unstable
   - lz4
   - numpy>=1.19.0
   - pandas>=1.3.0

--- a/default/environment-py38.yml
+++ b/default/environment-py38.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - python-blosc
   - cytoolz
-  - dask=2022.4.0
+  - dask=2022.1.1  # Versions after this are known to be unstable
   - lz4
   - numpy>=1.19.0
   - pandas>=1.3.0

--- a/default/environment-py39.yml
+++ b/default/environment-py39.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - python-blosc
   - cytoolz
-  - dask=2022.4.0
+  - dask=2022.1.1  # Versions after this are known to be unstable
   - lz4
   - numpy>=1.19.0
   - pandas>=1.3.0


### PR DESCRIPTION
We should revert the dask default version to the January release. The following releases are known to be unstable.

cc @dchudz 

This effectively reverts https://github.com/coiled/software-environments/pull/61