### PR TITLE
Use `coiled-runtime`

### DIFF
--- a/.github/workflows/ci-bump-coiled-runtime.yml
+++ b/.github/workflows/ci-bump-coiled-runtime.yml
@@ -1,4 +1,4 @@
-name: Check for new Dask version on conda-forge
+name: Check for new coiled-runtime version
 
 on:
   schedule:
@@ -11,19 +11,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Get latest Dask version
+      - name: Get latest coiled-runtime version
         id: latest_version
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
         with:
-          org: "conda-forge"
-          package: "dask"
+          # TODO: Update to conda-forge once coiled-runtime is available there
+          org: "coiled"
+          package: "coiled-runtime"
 
-      - name: Find and replace Dask version
+      - name: Find and replace coiled-runtime version
         id: find_and_replace
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
-          find: "dask=[.0-9]+"
-          replace: "dask=${{ steps.latest_version.outputs.version }}"
+          find: "coiled-runtime=[.0-9]+"
+          replace: "coiled-runtime=${{ steps.latest_version.outputs.version }}"
 
       - name: Output changed files
         run: echo ${{ steps.find_and_replace.outputs.modifiedFiles }}
@@ -33,11 +34,11 @@ jobs:
         with:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
-          title: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
+          commit-message: "Update coiled-runtime version to ${{ steps.latest_version.outputs.version }}"
+          title: "Update coiled-runtime version to ${{ steps.latest_version.outputs.version }}"
           reviewers: "jrbourbeau"
           branch: "upgrade-package-versions"
           body: |
-            A new Dask version has been detected.
+            A new coiled-runtime version has been detected.
 
-            Updated Dask to `${{ steps.latest_version.outputs.version }}`.
+            Updated coiled-runtime to `${{ steps.latest_version.outputs.version }}`.

--- a/default/environment-py37.yml
+++ b/default/environment-py37.yml
@@ -1,25 +1,7 @@
 channels:
+  - coiled
   - conda-forge
-  - defaults
 dependencies:
   - python=3.7
-  - pip
-  - python-blosc
-  - cytoolz
-  - dask=2022.1.1  # Versions after this are known to be unstable
-  - lz4
-  - numpy>=1.19.0
-  - pandas>=1.3.0
-  - bokeh>=2.1.1
-  - dask-image>=0.3.0
-  - dask-ml>=1.5.0
-  - s3fs>=2021.8.0
-  - numba
-  - pyarrow>=0.15.1
-  - python-graphviz
-  - scikit-learn>=0.23.1
-  - h5py
-  - xarray
-  - bottleneck
-  - requests
-  - pillow>=7.2.0
+  - coiled-runtime=0.0.3
+  - coiled=0.0.73

--- a/default/environment-py37.yml
+++ b/default/environment-py37.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - python=3.7
   - coiled-runtime=0.0.3
-  - coiled=0.0.73

--- a/default/environment-py38.yml
+++ b/default/environment-py38.yml
@@ -1,25 +1,7 @@
 channels:
+  - coiled
   - conda-forge
-  - defaults
 dependencies:
   - python=3.8
-  - pip
-  - python-blosc
-  - cytoolz
-  - dask=2022.1.1  # Versions after this are known to be unstable
-  - lz4
-  - numpy>=1.19.0
-  - pandas>=1.3.0
-  - bokeh>=2.1.1
-  - dask-image>=0.3.0
-  - dask-ml>=1.5.0
-  - s3fs>=2021.8.0
-  - numba
-  - pyarrow>=0.15.1
-  - python-graphviz
-  - scikit-learn>=0.23.1
-  - h5py
-  - xarray
-  - bottleneck
-  - requests
-  - pillow>=7.2.0
+  - coiled-runtime=0.0.3
+  - coiled=0.0.73

--- a/default/environment-py38.yml
+++ b/default/environment-py38.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - python=3.8
   - coiled-runtime=0.0.3
-  - coiled=0.0.73

--- a/default/environment-py39.yml
+++ b/default/environment-py39.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - python=3.9
   - coiled-runtime=0.0.3
-  - coiled=0.0.73

--- a/default/environment-py39.yml
+++ b/default/environment-py39.yml
@@ -1,25 +1,7 @@
 channels:
+  - coiled
   - conda-forge
-  - defaults
 dependencies:
   - python=3.9
-  - pip
-  - python-blosc
-  - cytoolz
-  - dask=2022.1.1  # Versions after this are known to be unstable
-  - lz4
-  - numpy>=1.19.0
-  - pandas>=1.3.0
-  - bokeh>=2.1.1
-  - dask-image>=0.3.0
-  - dask-ml>=1.5.0
-  - s3fs>=2021.8.0
-  - numba
-  - pyarrow>=0.15.1
-  - python-graphviz
-  - scikit-learn>=0.23.1
-  - h5py
-  - xarray
-  - bottleneck
-  - requests
-  - pillow>=7.2.0
+  - coiled-runtime=0.0.3
+  - coiled=0.0.73


### PR DESCRIPTION
This PR updates our default software environments to use the [`coiled-runtime` metapackage](https://github.com/coiled/coiled-runtime)

EDIT: cc @ncclementi @dchudz @ntabris @hayesgb 